### PR TITLE
Add Keypad lib + cleanup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DRUM_2024_V1
+
 ESP32 DRUM SYNTH MACHINE
 
 This is my DRUM SYNTH LOFI MACHINE.
@@ -6,15 +7,18 @@ This is my DRUM SYNTH LOFI MACHINE.
 ![IMG_20240406_150440](https://github.com/zircothc/DRUM_2004_V1/assets/17828930/c8327dc2-a3f7-4d81-8d82-ebfe2a7c45c3)
 
 # Synth engine:
-- Wavetable synthesizer based on DZL Arduino library "The Synth" (https://github.com/dzlonline/the_synth)
+
+- Wavetable synthesizer based on DZL Arduino library ["The Synth"](https://github.com/dzlonline/the_synth)
 - 16 sound polyphony
 - Sound parameters: Table, Length, Envelope, Pitch, Modulation, + Volume, Pan and Filter.
-- Filter (LowPassFilter) comes from Mozzi library (https://github.com/sensorium/Mozzi)
+- Filter (LowPassFilter) comes from [Mozzi Library](https://github.com/sensorium/Mozzi)
 
 SEQUENCER:
+
 - 16 step/pattern editor and random generators (pattern, sound parameters and notes)
-  
+
 # Hardware:
+
 - Lolin S2 Mini (ESP32 S2)
 - PCM5102A I2s dac
 - 24 push buttons (8x3)
@@ -25,17 +29,19 @@ SEQUENCER:
 # Software:
 
 IDE:
-Arduino 1.8.19
+Arduino `1.8.19` (Won't compile with 2.x!)
 
 Boards:
-Expressif Systems 2.0.14
+Expressif Systems `2.0.14` (Tested fine up to `2.0.17`)
 
 Board: Lolin S2 Mini
 
-Libraries:
-- Sequencer Timer - uClock: https://github.com/midilab/uClock
-- RGB Leds - Adafruit Neopixel: https://github.com/adafruit/Adafruit_NeoPixel
-- OLED - u8g2: https://github.com/olikraus/u8g2
+Necessary Libraries:
+
+- Sequencer Timer - [uClock](https://github.com/midilab/uClock)
+- RGB Leds - [Adafruit Neopixel](https://github.com/adafruit/Adafruit_NeoPixel)
+- OLED - [u8g2](https://github.com/olikraus/u8g2)
+- Button input - [Keypad](https://github.com/Chris--A/Keypad)
 
 # Notes:
 
@@ -45,23 +51,26 @@ STL 3D model uploaded.
 
 Cheat sheet style PDF uploaded.
 
-Join solder pads near SCK pin in PCM5102A module.
-Update: solder also pads on the back:
-1 Low
-2 Low
-3 High
-4 Low
+Join solder pads near SCK pin on PCM5102A module.
 
+**Update**: 
 
+- Solder pads on the back of PCM5102A module ([more info](https://github.com/pschatzmann/ESP32-A2DP/wiki/External-DAC#pcm5102-dac))
+  
+  - H1L: FLT - Low
+  
+  - H2L: DEMP - Low
+  
+  - H3L: XSMT - High
+  
+  - H4L: FMT - Low
 
 Video demo of the prototype:
 
 [![IMG_20240406_150231](https://img.youtube.com/vi/rXl1gpWJp-g/0.jpg)](https://www.youtube.com/watch?v=rXl1gpWJp-g)
 
-
 Prototype:
 ![IMG_20240406_150231](https://github.com/zircothc/DRUM_2004_V1/assets/17828930/feb9b928-f76a-4b51-93ea-a7afbd6a5c28)
-
 
 # PCB, PROJECT & FINAL LOOK:
 
@@ -81,4 +90,3 @@ SIZE: FINAL BUILD vs PROTOTYPE
 
 TWO MACHINES IN SYNC
 ![sync](https://github.com/zircothc/DRUM_2004_V1/assets/17828930/0adc1eed-482d-4931-8327-f6911d9ab73b)
-


### PR DESCRIPTION
Added missing Keypad library dependency, cleaned up some of the links and notes around the PCM5102A modifications (pretty sure only Pad #3 XFMT "soft-mute" needs to be pulled high to enable audio output but best to do all 4).